### PR TITLE
Fix hideCursorTimer

### DIFF
--- a/bilibili/PlayerView/PlayerView.mm
+++ b/bilibili/PlayerView/PlayerView.mm
@@ -697,11 +697,16 @@ GetInfo:NSDictionary *VideoInfoJson = [self getVideoInfo:firstVideo];
 }
 
 - (void)hideCursor:(id)sender {
-//    if(isPlaying) {
+    if(mpv) {
         if (CGEventSourceSecondsSinceLastEventType(kCGEventSourceStateCombinedSessionState, kCGEventMouseMoved) >= 1) {
             [NSCursor setHiddenUntilMouseMoves:YES];
         }
-//    }
+    }
+}
+
+- (void)viewWillDisappear {
+    [hideCursorTimer invalidate];
+    hideCursorTimer = nil;
 }
 
 @end


### PR DESCRIPTION
Only hide cursor when mpv exists.
Invalidate hideCursorTimer when PlayerView disappear.