### PR TITLE
直播设置增加线路选择设置

### DIFF
--- a/bilibili/Base.lproj/Main.storyboard
+++ b/bilibili/Base.lproj/Main.storyboard
@@ -1339,10 +1339,10 @@ GQ
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <objectValues>
-                                        <string>原始地址</string>
-                                        <string>http://live-play-1.acgvideo.com/live/</string>
-                                        <string>http://live-play-2.acgvideo.com/live/</string>
-                                        <string>http://live-play-3.acgvideo.com/live/</string>
+                                        <string>主线</string>
+                                        <string>支线1</string>
+                                        <string>支线2</string>
+                                        <string>支线3</string>
                                     </objectValues>
                                 </comboBoxCell>
                                 <connections>

--- a/bilibili/Base.lproj/Main.storyboard
+++ b/bilibili/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <scenes>
         <!--Window Controller-->
@@ -43,17 +43,17 @@
                                 <rect key="frame" x="20" y="152" width="359" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <clipView key="contentView" id="LK4-eA-AGj">
-                                    <rect key="frame" x="1" y="1" width="342" height="78"/>
+                                    <rect key="frame" x="1" y="1" width="357" height="78"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textView importsGraphics="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" usesFontPanel="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" smartInsertDelete="YES" id="vbw-5q-kZk">
                                             <rect key="frame" x="0.0" y="0.0" width="342" height="78"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <size key="minSize" width="342" height="78"/>
+                                            <size key="minSize" width="357" height="78"/>
                                             <size key="maxSize" width="463" height="10000000"/>
                                             <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="minSize" width="342" height="78"/>
+                                            <size key="minSize" width="357" height="78"/>
                                             <size key="maxSize" width="463" height="10000000"/>
                                         </textView>
                                     </subviews>
@@ -64,7 +64,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="rih-nB-JqP">
-                                    <rect key="frame" x="343" y="1" width="15" height="78"/>
+                                    <rect key="frame" x="342" y="1" width="16" height="78"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
@@ -691,10 +691,10 @@ GQ
                                             <rect key="frame" x="0.0" y="0.0" width="468" height="230"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <size key="minSize" width="468" height="230"/>
+                                            <size key="minSize" width="483" height="230"/>
                                             <size key="maxSize" width="485" height="10000000"/>
                                             <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="minSize" width="468" height="230"/>
+                                            <size key="minSize" width="483" height="230"/>
                                             <size key="maxSize" width="485" height="10000000"/>
                                         </textView>
                                     </subviews>
@@ -705,7 +705,7 @@ GQ
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Tku-Hz-Coo">
-                                    <rect key="frame" x="469" y="1" width="15" height="230"/>
+                                    <rect key="frame" x="468" y="1" width="16" height="230"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
@@ -935,10 +935,10 @@ GQ
                                             <rect key="frame" x="0.0" y="0.0" width="478" height="268"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <size key="minSize" width="463" height="268"/>
+                                            <size key="minSize" width="478" height="268"/>
                                             <size key="maxSize" width="480" height="10000000"/>
                                             <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="minSize" width="463" height="268"/>
+                                            <size key="minSize" width="478" height="268"/>
                                             <size key="maxSize" width="480" height="10000000"/>
                                         </textView>
                                     </subviews>
@@ -949,7 +949,7 @@ GQ
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Ft0-cT-2BV">
-                                    <rect key="frame" x="464" y="1" width="15" height="268"/>
+                                    <rect key="frame" x="463" y="1" width="16" height="268"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
@@ -1039,11 +1039,11 @@ GQ
                 <customObject id="g1X-ko-pK9" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <viewController title="通用设置" id="z8a-gg-iMj" userLabel="General Settings" customClass="Settings" sceneMemberID="viewController">
                     <view key="view" id="TEq-hT-EBz">
-                        <rect key="frame" x="0.0" y="0.0" width="654" height="460"/>
+                        <rect key="frame" x="0.0" y="0.0" width="654" height="524"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <button id="hj3-k4-IwT">
-                                <rect key="frame" x="25" y="424" width="412" height="18"/>
+                                <rect key="frame" x="25" y="488" width="412" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="自动换P" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="IwE-aZ-Bxq">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1054,7 +1054,7 @@ GQ
                                 </connections>
                             </button>
                             <button id="aRT-dE-rbd">
-                                <rect key="frame" x="25" y="404" width="412" height="18"/>
+                                <rect key="frame" x="25" y="468" width="412" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="禁用实时弹幕显示（推迟发布）" bezelStyle="regularSquare" imagePosition="left" alignment="left" enabled="NO" inset="2" id="sbQ-fv-ZWa">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1065,7 +1065,7 @@ GQ
                                 </connections>
                             </button>
                             <button id="AeH-XX-C7T">
-                                <rect key="frame" x="25" y="384" width="611" height="18"/>
+                                <rect key="frame" x="25" y="448" width="611" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="启用 VT 硬解模式（发热太高尝试开启，可能导致弹幕 FPS 降低）" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Dkz-2s-yhr">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1076,7 +1076,7 @@ GQ
                                 </connections>
                             </button>
                             <comboBox verticalHuggingPriority="750" id="k65-FX-xi6">
-                                <rect key="frame" x="27" y="176" width="99" height="26"/>
+                                <rect key="frame" x="27" y="240" width="99" height="26"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="4" id="UtE-Jc-IKj">
                                     <font key="font" metaFont="system"/>
@@ -1094,7 +1094,7 @@ GQ
                                 </connections>
                             </comboBox>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="jlv-di-fx2">
-                                <rect key="frame" x="25" y="214" width="56" height="17"/>
+                                <rect key="frame" x="25" y="278" width="56" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="优先画质" id="Sd9-OH-JrH">
                                     <font key="font" metaFont="system"/>
@@ -1103,7 +1103,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="LGC-Jg-Mns">
-                                <rect key="frame" x="129" y="214" width="170" height="17"/>
+                                <rect key="frame" x="129" y="278" width="170" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="IP 伪造 ( 大陆用户请勿开启 )" id="vMH-pa-ZpX">
                                     <font key="font" metaFont="system"/>
@@ -1112,7 +1112,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="v5E-aw-wG4">
-                                <rect key="frame" x="312" y="214" width="100" height="17"/>
+                                <rect key="frame" x="312" y="278" width="100" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="弹幕大小参数" id="dJb-2c-b1m">
                                     <font key="font" metaFont="system"/>
@@ -1121,7 +1121,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" id="ajt-jS-Z4K">
-                                <rect key="frame" x="314" y="180" width="89" height="22"/>
+                                <rect key="frame" x="314" y="244" width="89" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="默认25" drawsBackground="YES" id="pXu-zi-Y7u">
                                     <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Dl4-M8-KPr"/>
@@ -1134,7 +1134,7 @@ GQ
                                 </connections>
                             </textField>
                             <comboBox verticalHuggingPriority="750" id="JLT-R0-aaz">
-                                <rect key="frame" x="131" y="176" width="169" height="26"/>
+                                <rect key="frame" x="131" y="240" width="169" height="26"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="4" id="P8V-DP-s5N">
                                     <font key="font" metaFont="system"/>
@@ -1153,7 +1153,7 @@ GQ
                                 </connections>
                             </comboBox>
                             <slider verticalHuggingPriority="750" id="7WK-cw-6iP">
-                                <rect key="frame" x="25" y="111" width="266" height="21"/>
+                                <rect key="frame" x="25" y="175" width="266" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <sliderCell key="cell" state="on" alignment="left" minValue="-1" maxValue="1" tickMarkPosition="above" sliderType="linear" id="S2O-CH-AsH"/>
                                 <connections>
@@ -1161,7 +1161,7 @@ GQ
                                 </connections>
                             </slider>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="cJc-Xd-aCd">
-                                <rect key="frame" x="25" y="138" width="319" height="17"/>
+                                <rect key="frame" x="25" y="202" width="319" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="弹幕移动速度" id="zpf-lu-2U6">
                                     <font key="font" metaFont="system"/>
@@ -1170,7 +1170,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="8GO-QK-utF">
-                                <rect key="frame" x="30" y="20" width="481" height="17"/>
+                                <rect key="frame" x="30" y="84" width="481" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="3.所有设置将在下次开始播放时生效，文本框需要按回车保存" id="43T-62-L37">
                                     <font key="font" metaFont="system"/>
@@ -1179,7 +1179,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="CNv-ip-Ik8">
-                                <rect key="frame" x="30" y="71" width="481" height="17"/>
+                                <rect key="frame" x="30" y="135" width="481" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="1.弹幕字体计算方式为 视频高度除以字体参数 ，参数越大 弹幕越小" id="dYW-v7-aMe">
                                     <font key="font" metaFont="system"/>
@@ -1188,7 +1188,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Ubj-zp-AMU">
-                                <rect key="frame" x="30" y="46" width="481" height="17"/>
+                                <rect key="frame" x="30" y="110" width="481" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="2.仅支持在 /System/Library/Fonts/ 中的弹幕字体" id="QaX-PH-0zE">
                                     <font key="font" metaFont="system"/>
@@ -1197,7 +1197,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <button id="1aB-2H-H2d">
-                                <rect key="frame" x="25" y="364" width="611" height="18"/>
+                                <rect key="frame" x="25" y="428" width="611" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="禁用保持视频比例（让视频撑满窗口）" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="lBw-oC-I1B">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1208,7 +1208,7 @@ GQ
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="OIq-ag-IQD">
-                                <rect key="frame" x="419" y="214" width="75" height="17"/>
+                                <rect key="frame" x="419" y="278" width="75" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="弹幕字体" id="6ZU-bU-OI7">
                                     <font key="font" metaFont="system"/>
@@ -1217,7 +1217,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" id="iLa-hJ-dgh">
-                                <rect key="frame" x="421" y="180" width="88" height="22"/>
+                                <rect key="frame" x="421" y="244" width="88" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="STHeiti" drawsBackground="YES" id="A8r-5c-QC5">
                                     <font key="font" metaFont="system"/>
@@ -1229,7 +1229,7 @@ GQ
                                 </connections>
                             </textField>
                             <slider verticalHuggingPriority="750" id="dP9-DC-elz">
-                                <rect key="frame" x="348" y="111" width="288" height="21"/>
+                                <rect key="frame" x="348" y="175" width="288" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <sliderCell key="cell" state="on" alignment="left" maxValue="1" doubleValue="0.80000000000000004" tickMarkPosition="above" sliderType="linear" id="NRf-l9-8Cv"/>
                                 <connections>
@@ -1237,7 +1237,7 @@ GQ
                                 </connections>
                             </slider>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="wLx-ha-LJe">
-                                <rect key="frame" x="348" y="138" width="297" height="17"/>
+                                <rect key="frame" x="348" y="202" width="297" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="弹幕透明度" id="CuV-Ec-HRG">
                                     <font key="font" metaFont="system"/>
@@ -1246,7 +1246,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Pn0-p5-eUE">
-                                <rect key="frame" x="524" y="214" width="112" height="17"/>
+                                <rect key="frame" x="524" y="278" width="112" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="最大缓冲( KB )" id="GCK-CB-vEX">
                                     <font key="font" metaFont="system"/>
@@ -1255,7 +1255,7 @@ GQ
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" id="nHb-Pd-fXL">
-                                <rect key="frame" x="526" y="180" width="88" height="22"/>
+                                <rect key="frame" x="526" y="244" width="88" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="" drawsBackground="YES" id="QiJ-fu-Jcf">
                                     <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="OGs-UT-bmo"/>
@@ -1268,7 +1268,7 @@ GQ
                                 </connections>
                             </textField>
                             <button id="iLo-qY-8yG">
-                                <rect key="frame" x="25" y="344" width="491" height="18"/>
+                                <rect key="frame" x="25" y="408" width="491" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="禁用写入播放历史" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="cCa-ax-BU2">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1279,7 +1279,7 @@ GQ
                                 </connections>
                             </button>
                             <button id="5yv-E4-e3g">
-                                <rect key="frame" x="25" y="324" width="491" height="18"/>
+                                <rect key="frame" x="25" y="388" width="491" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="关闭底部弹幕" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="6pD-zG-Fl9">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1290,7 +1290,7 @@ GQ
                                 </connections>
                             </button>
                             <button id="QLp-in-QLo">
-                                <rect key="frame" x="25" y="285" width="611" height="18"/>
+                                <rect key="frame" x="25" y="349" width="611" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="播放优先 MP4 格式（发热更小，播放更快，可能有画质损失）" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="6zZ-XI-ZEK">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1301,7 +1301,7 @@ GQ
                                 </connections>
                             </button>
                             <button id="wjO-cr-vaH">
-                                <rect key="frame" x="25" y="265" width="611" height="18"/>
+                                <rect key="frame" x="25" y="329" width="611" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="下载优先 MP4 格式（方便手机观看，且没有被官方限速，下载更快）" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="hFO-eX-oZN">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1312,7 +1312,7 @@ GQ
                                 </connections>
                             </button>
                             <button id="djV-1w-XE2">
-                                <rect key="frame" x="25" y="304" width="491" height="18"/>
+                                <rect key="frame" x="25" y="368" width="491" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="反转手势方向" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Qmf-Aa-Lqo">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1322,6 +1322,33 @@ GQ
                                     <action selector="changeGestureDirection:" target="z8a-gg-iMj" id="8O2-rc-U2I"/>
                                 </connections>
                             </button>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Toj-Je-LEz">
+                                <rect key="frame" x="30" y="52" width="82" height="17"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="直播线路选择" id="NhR-6K-Kfk">
+                                    <font key="font" size="13" name=".PingFangSC-Regular"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <comboBox verticalHuggingPriority="750" id="9wD-nS-AMl">
+                                <rect key="frame" x="143" y="48" width="337" height="26"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="4" id="Dnk-Eh-A3D">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <objectValues>
+                                        <string>原始地址</string>
+                                        <string>http://live-play-1.acgvideo.com/live/</string>
+                                        <string>http://live-play-2.acgvideo.com/live/</string>
+                                        <string>http://live-play-3.acgvideo.com/live/</string>
+                                    </objectValues>
+                                </comboBoxCell>
+                                <connections>
+                                    <action selector="liveLineChanged:" target="z8a-gg-iMj" id="8QQ-0h-D0O"/>
+                                </connections>
+                            </comboBox>
                         </subviews>
                     </view>
                     <connections>
@@ -1337,6 +1364,7 @@ GQ
                         <outlet property="disablebottomComment" destination="5yv-E4-e3g" id="zXF-lZ-D8g"/>
                         <outlet property="fontName" destination="iLa-hJ-dgh" id="jDT-c4-qHR"/>
                         <outlet property="fontsize" destination="ajt-jS-Z4K" id="ouz-gu-SI4"/>
+                        <outlet property="liveLineBox" destination="9wD-nS-AMl" id="Y7X-4g-r77"/>
                         <outlet property="maxBufferSize" destination="nHb-Pd-fXL" id="0io-Gk-bxi"/>
                         <outlet property="playMP4" destination="QLp-in-QLo" id="Nan-Qj-eQF"/>
                         <outlet property="qualityBox" destination="k65-FX-xi6" id="XPQ-mh-vcg"/>
@@ -1344,7 +1372,7 @@ GQ
                     </connections>
                 </viewController>
             </objects>
-            <point key="canvasLocation" x="1888" y="-407"/>
+            <point key="canvasLocation" x="1888" y="-375"/>
         </scene>
         <!--MPV Settings-->
         <scene sceneID="wHe-A7-2U0">

--- a/bilibili/Settings/Settings.h
+++ b/bilibili/Settings/Settings.h
@@ -27,4 +27,5 @@
 @property (weak) IBOutlet NSTextField *maxBufferSize;
 @property (weak) IBOutlet NSButton *changeGestureDirection;
 
+@property (weak) IBOutlet NSComboBox *liveLineBox;
 @end

--- a/bilibili/Settings/Settings.m
+++ b/bilibili/Settings/Settings.m
@@ -46,6 +46,15 @@
     }else{
         [self.qualityBox setStringValue:NSLocalizedStringFromTable(@"UtE-Jc-IKj.ibShadowedObjectValues[3]", @"Main", @"原画")];
     }
+    
+    NSString* liveLine = [settingsController objectForKey:@"liveLine"];
+    NSLog(@"[liveLine origin]:%@", liveLine);
+    if (liveLine != nil) {
+        [self.liveLineBox setStringValue:liveLine];
+    } else {
+        [self.liveLineBox setStringValue: @"原始地址"];
+    }
+    
 
     
     NSString *IP = [settingsController objectForKey:@"xff"];
@@ -99,6 +108,11 @@
         NSLog(@"Select max quanlity");
         [settingsController setInteger:4 forKey:@"quality"];
     }
+    [settingsController synchronize];
+}
+- (IBAction)liveLineChanged:(id)sender {
+    NSString *line = [self.liveLineBox stringValue];
+    [settingsController setObject:line forKey:@"liveLine"];
     [settingsController synchronize];
 }
 - (IBAction)transparencyChanged:(id)sender {
@@ -168,5 +182,7 @@
 - (NSInteger)randomNumberBetween:(NSInteger)min maxNumber:(NSInteger)max
 {
     return min + arc4random_uniform((u_int32_t)max - (u_int32_t)min + 1);
+}
+- (IBAction)liveLineBox:(NSComboBox *)sender {
 }
 @end

--- a/bilibili/Settings/Settings.m
+++ b/bilibili/Settings/Settings.m
@@ -52,7 +52,7 @@
     if (liveLine != nil) {
         [self.liveLineBox setStringValue:liveLine];
     } else {
-        [self.liveLineBox setStringValue: @"原始地址"];
+        [self.liveLineBox setStringValue: @"主线"];
     }
     
 

--- a/bilibili/VideoProvider/VP_Bilibili.m
+++ b/bilibili/VideoProvider/VP_Bilibili.m
@@ -30,14 +30,14 @@
     self = [super init];
     if(self) {
         ud = [NSUserDefaults standardUserDefaults];
-
+        
         // HWID
         self.hwid = [ud objectForKey:@"hwid_2"];
         if([self.hwid length] < 4){
             self.hwid  = [self getRandomHWID];
             [ud setObject:self.hwid forKey:@"hwid_2"];
         }
-
+        
         self.userAgent = @"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36";
     }
     return self;
@@ -52,13 +52,13 @@
         params[@"live"] = @"true";
         return params;
     }
-
+    
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\/video\\/av(\\d+)(\\/index.html|\\/index_(\\d+).html)?" options:NSRegularExpressionCaseInsensitive error:nil];
-
+    
     NSTextCheckingResult *match = [regex firstMatchInString:URL options:0 range:NSMakeRange(0, [URL length])];
-
+    
     NSRange aidRange = [match rangeAtIndex:1];
-
+    
     if(aidRange.length > 0){
         params[@"aid"] = [URL substringWithRange:aidRange];
         NSRange pidRange = [match rangeAtIndex:3];
@@ -71,52 +71,52 @@
         params[@"aid"] = @"0";
         params[@"pid"] = @"1";
     }
-
+    
     params[@"url"] = URL;
-
+    
     return params;
 }
 
 - (NSString *)getPlaybackRequestURL: (NSDictionary *)params{
     int quality = [self getQuality];
     NSString *type = [self getFormat:[params[@"download"] boolValue]];
-
+    
     NSLog(@"[VP_Bilibili] AV: %@, CID: %@, PID: %@", params[@"aid"], params[@"cid"], params[@"pid"]);
-
+    
     [self writeHistory:params[@"cid"] :params[@"aid"]];
-
+    
 //    NSString *req_path = [NSString stringWithFormat:@"platform=android&_device=android&_hwid=%@&_aid=%@&_tid=0&_p=%@&_down=0&cid=%@&quality=%d&otype=json&appkey=%@&type=%@",
 //                          self.hwid, // Hardware ID ( Generate on first start )
 //                          params[@"aid"], // Page ID ( AV )
 //                          params[@"pid"], // Page Number
 //                          params[@"cid"], // Video ID
 //                          quality,APIKey,type];
-//
+//    
 //    NSString *req_sign = [self getSign:req_path];
-//
+//    
 //    NSString *req_url = [NSString stringWithFormat:@"http://interface.bilibili.com/playurl?%@&sign=%@",req_path,req_sign];
 
     int rnd = arc4random_uniform(9999);
-
+    
     NSString *req_path = [NSString stringWithFormat:@"platform=android&cid=%@&quality=%d&otype=json&appkey=%@&type=%@&rnd=%d",
                           params[@"cid"], // Video ID
                           quality,APIKey,type,rnd];
-
+    
     NSString *req_sign = [self getSign:req_path];
-
+    
     NSString *req_url = [NSString stringWithFormat:@"http://interface.bilibili.com/playurl?%@&sign=%@",req_path,req_sign];
-
+    
     NSLog(@"[VP_Bilibili] API Request URL: %@", req_url);
-
+    
     return req_url;
 }
 
 - (NSString *)getLiveRequestURL: (NSDictionary *)params{
     NSLog(@"[VP_Bilibili] LiveRoom: %@", params[@"cid"]);
-
+    
 //    NSString *uuid = [[NSUUID UUID] UUIDString];
 //    NSString *hwid = [self getRandomHWID];
-//
+//    
 //    NSString *req_path = [NSString stringWithFormat:@"platform=android&_appver=406001&_buvid=%@infoc&_device=android&_hwid=%@&_aid=0&_tid=0&_p=%@&_down=0&cid=%@&quality=1&otype=json&appkey=%@&type=mp4",
 //                          uuid, // BUVID ( Unkown , Random here )
 //                          hwid, // Hardware ID ( Random here , avoid BUVID
@@ -125,21 +125,25 @@
 //                          APIKey];
 //
 //    NSString *req_sign = [self getSign:req_path];
-//
+//    
 //    NSString *req_url = [NSString stringWithFormat:@"http://live.bilibili.com/api/playurl?%@&sign=%@",req_path,req_sign];
 
     int rnd = arc4random_uniform(9999);
-
-    NSString *req_path = [NSString stringWithFormat:@"platform=android&cid=%@&quality=1&otype=json&appkey=%@&type=mp4&rnd=%d",
+    
+//    NSString *req_path = [NSString stringWithFormat:@"platform=android&cid=%@&quality=1&otype=json&appkey=%@&type=mp4&rnd=%d",
+//                          params[@"cid"], // Video ID
+//                          APIKey,rnd];
+    
+    NSString *req_path = [NSString stringWithFormat:@"platform=android&cid=%@&quality=1&otype=xml&appkey=%@&type=mp4&rnd=%d",
                           params[@"cid"], // Video ID
                           APIKey,rnd];
-
+    
     NSString *req_sign = [self getSign:req_path];
-
+    
     NSString *req_url = [NSString stringWithFormat:@"http://live.bilibili.com/api/playurl?%@&sign=%@",req_path,req_sign];
-
+    
     NSLog(@"[VP_Bilibili] API Request URL: %@", req_url);
-
+    
     return req_url;
 }
 
@@ -154,56 +158,38 @@
 //      }
 
 
-- (NSString *) parseLiveURL: (NSString *)url {
-    NSLog(@"[liveline]: origin url: %@", url);
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@".*?(live_.*?.flv).*?" options:NSRegularExpressionCaseInsensitive error:nil];
-    NSTextCheckingResult *match = [regex firstMatchInString:url options:0 range:NSMakeRange(0, [url length])];
-
-    NSRange aidRange = [match rangeAtIndex:1];
-
-    if(aidRange.length > 0){
-        NSString* new_url = [url substringWithRange:aidRange];
-        NSString* liveLine = (NSString *)[ud objectForKey:@"liveLine"];
-        NSLog(@"[liveLine]: %@", liveLine);
-        if ([liveLine isEqualToString:@"原始地址"]) {
-            return url;
-        }
-        NSLog(@"[regex]: %@", new_url);
-        return [NSString stringWithFormat:@"%@%@", liveLine, new_url];
-    }
-    return url;
-}
-
 - (VideoAddress *) getVideoAddress: (NSDictionary *)params{
     if(!params[@"cid"]){
         [NSException raise:@VP_PARAM_ERROR format:@"CID Cannot be empty"];
         return NULL;
     }
-
+                      
 getUrl: NSLog(@"[VP_Bilibili] Getting video url");
 
     NSString *pbUrl;
-
+    Boolean isLive = NO;
+    
     if(!params[@"live"]){
         pbUrl = [self getPlaybackRequestURL:params];
     }else{
         pbUrl = [self getLiveRequestURL:params];
+        isLive = YES;
     }
-
+    
     NSURL* URL = [NSURL URLWithString:pbUrl];
-
+    
     NSString *fakeIP = [self getFakeIP:params];
 
     NSDictionary *videoResult;
-
+    
     // Their offical android/ios client is using dynamic downloaded lua to parse video
     // So I've implemented a lua interpreter , will find the appkey & secret automatically
     // My continuous integration server will build new dynamic library if new key detected
     // This program will download new dynamic library on startup, and verify the digital signature of  library, load it into memory
-
-
+    
+    
     // Build-in parser's result(ws.acgvideo.com/path.flv?*&or=xxx the "or" param) have speed limit , so use dynamic parser by default
-
+    
 #ifndef DEBUG
     VP_Plugin *plugin = [[PluginManager sharedInstance] Get:@"bilibili-resolveAddr"];
     if(plugin){
@@ -218,9 +204,9 @@ getUrl: NSLog(@"[VP_Bilibili] Getting video url");
     }
 #endif
 
-
+    
 parseJSON: NSLog(@"[VP_Bilibili] Parsing result");
-
+    
     NSArray *dUrls = [videoResult objectForKey:@"durl"];
     if([dUrls count] == 0 || ![videoResult objectForKey:@"result"]){
         if(FLVFailRetry){
@@ -232,70 +218,85 @@ parseJSON: NSLog(@"[VP_Bilibili] Parsing result");
             videoResult = [self dynamicPluginParser:params];
             goto parseJSON;
         }else{
-            FLVFailRetry = YES;
-            NSLog(@"[VP_Bilibili] Retring resolve with FLV format");
-            goto getUrl;
+            if (!isLive){
+                FLVFailRetry = YES;
+                NSLog(@"[VP_Bilibili] Retring resolve with FLV format");
+                goto getUrl;
+            }
+            
         }
     }
-
+    
 genAddress: FLVFailRetry = NO;
-
+    
     VideoAddress *video = [[VideoAddress alloc] init];
     [video setUserAgent:self.userAgent];
 
-    BOOL URLisString = [[[dUrls valueForKey:@"url"] className] isEqualToString:@"__NSCFString"];
-
-    if(URLisString){ // URL is String ( Some old videos , Single fragment )
-
-
-
-        NSString *url = [dUrls valueForKey:@"url"];
-        [video addDefaultPlayURL:url];
-
-        url = [self parseLiveURL: url];
-        [video setFirstFragmentURL:url];
-        NSLog(@"[parsed_url]: %@", url);
-
-    }else if([dUrls count] == 1){ // URL is Array ( Most MP4 videos, Single fragment )
-
-        NSString *url = [[dUrls objectAtIndex:0] valueForKey:@"url"];
-
-        url = [self parseLiveURL: url];
-        [video addDefaultPlayURL:url];
-        NSLog(@"[parsed_url]: %@", url);
-
-        [video setFirstFragmentURL:url];
-
-        NSArray *bUrls = [[dUrls objectAtIndex:0] valueForKey:@"backup_url"];
-        if([bUrls count] > 0){
-            for (NSString *burl in bUrls) {
-                [video addBackupURL:@[burl]];
-            }
+    if (isLive){
+        NSString* liveLine = (NSString *)[ud objectForKey:@"liveLine"];
+        NSLog(@"[liveLine]: %@", liveLine);
+        NSString *url;
+        if ([liveLine isEqualToString:@"主线"]) {
+            url = [dUrls objectAtIndex:0];
+        } else if ([liveLine isEqualToString:@"支线1"]) {
+            url = [dUrls objectAtIndex:1];
+        } else if ([liveLine isEqualToString:@"支线2"]) {
+            url = [dUrls objectAtIndex:2];
+        } else{
+            url = [dUrls objectAtIndex:3];
         }
+        
+        [video addDefaultPlayURL:url];
+        [video setFirstFragmentURL:url];
 
-    }else{ // URL is Array ( Most FLV videos, Multi fragment )
-
-        for (NSDictionary *match in dUrls) {
-            NSString *url = [match valueForKey:@"url"];
-            if(![[video firstFragmentURL] length]){ // Set first fragment url
-                [video setFirstFragmentURL:url];
-            }
-
-            url = [self parseLiveURL: url];
+    } else {
+        
+        BOOL URLisString = [[[dUrls valueForKey:@"url"] className] isEqualToString:@"__NSCFString"];
+        
+        if(URLisString){ // URL is String ( Some old videos , Single fragment )
+            
+            NSString *url = [dUrls valueForKey:@"url"];
             [video addDefaultPlayURL:url];
-            NSLog(@"[parsed_url]: %@", url);
-
+            
+            [video setFirstFragmentURL:url];
+            
+        }else if([dUrls count] == 1){ // URL is Array ( Most MP4 videos, Single fragment )
+            
+            NSString *url = [[dUrls objectAtIndex:0] valueForKey:@"url"];
+            
+            [video addDefaultPlayURL:url];
+            
+            [video setFirstFragmentURL:url];
+            
+            NSArray *bUrls = [[dUrls objectAtIndex:0] valueForKey:@"backup_url"];
+            if([bUrls count] > 0){
+                for (NSString *burl in bUrls) {
+                    [video addBackupURL:@[burl]];
+                }
+            }
+            
+        }else{ // URL is Array ( Most FLV videos, Multi fragment )
+            
+            for (NSDictionary *match in dUrls) {
+                NSString *url = [match valueForKey:@"url"];
+                if(![[video firstFragmentURL] length]){ // Set first fragment url
+                    [video setFirstFragmentURL:url];
+                }
+                [video addDefaultPlayURL:url];
+            }
+            
         }
-
     }
-
+    
+    
+    
     // Sina old video ( only flv )
     if([[video firstFragmentURL] isEqualToString:@"http://v.iask.com/v_play_ipad.php?vid=false"]){
         FLVFailRetry = YES;
         NSLog(@"[VP_Bilibili] Retring resolve with FLV format");
         goto getUrl;
     }
-
+    
     // Anti Hot Linking
 
     if([[video firstFragmentURL] containsString:@".hdslb."] || // *.hdslb.* only have static content
@@ -305,7 +306,7 @@ genAddress: FLVFailRetry = NO;
         videoResult = [self dynamicPluginParser:params];
         goto parseJSON;
     }
-
+    
     return video;
 }
 
@@ -313,13 +314,13 @@ genAddress: FLVFailRetry = NO;
     NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:URL];
     request.HTTPMethod = @"GET";
     request.timeoutInterval = 5;
-
-
+    
+    
     if(fakeIP){
         [request setValue:fakeIP forHTTPHeaderField:@"X-Forwarded-For"];
         [request setValue:fakeIP forHTTPHeaderField:@"Client-IP"];
     }
-
+    
 //    [request setValue:[ud objectForKey:@"cookie"] forHTTPHeaderField:@"Cookie"];
 //    [request setValue:self.userAgent forHTTPHeaderField:@"User-Agent"];
 //    [request setValue:@"trailers" forHTTPHeaderField:@"TE"];
@@ -340,13 +341,32 @@ genAddress: FLVFailRetry = NO;
         return NULL;
     }
     NSMutableDictionary *videoResult = [NSJSONSerialization JSONObjectWithData:respData options:0 error:&error];
-
+    
     if(error){
         NSLog(@"[VP_Bilibili] JSON Parse Error: %@",error);
+        
+        NSString *rt = [[NSString alloc] initWithData:respData
+                                                 encoding:NSASCIIStringEncoding];
+        NSLog(@"[xml response]:%@", rt);
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"<!\\[CDATA\\[(http.*)\\]\\]><\\/.*url>" options:NSRegularExpressionCaseInsensitive error:nil];
+        
+        NSArray<NSTextCheckingResult *> *match_new = [regex matchesInString:rt options:0 range:NSMakeRange(0, [rt length])];
+        NSMutableArray *result = [[NSMutableArray alloc]initWithCapacity:[match_new count]];
+        for (int i = 0; i < [match_new count]; i++) {
+            NSRange rg = [[match_new objectAtIndex:i] rangeAtIndex:1];
+            if (rg.length > 0){
+                NSString* rt_new = [rt substringWithRange:rg];
+                NSLog(@"%@", rt_new);
+                [result insertObject:rt_new atIndex:i];
+            }
+        }
+        NSDictionary *dict1 = [NSDictionary dictionaryWithObject:result forKey:@"durl"];
+        return dict1;
+        
         [NSException raise:@VP_BILI_JSON_ERROR format:@"视频解析出现错误，JSON 解析失败，可能的原因：\n1. 您的网络被劫持\n2. Bilibili 服务器出现故障\n请尝试以下步骤：\n1. 尝试更换网络\n2. 过一会再试\n\n如果您确信是软件问题，请点击帮助 -- 反馈"];
         return NULL;
     }
-
+    
     return videoResult;
 }
 
@@ -365,39 +385,39 @@ genAddress: FLVFailRetry = NO;
         if([type isEqualToString:@"mp4"]){
             intIsMp4 = 1;
         }
-
+        
         NSString *url = params[@"url"];
         if(!url){
             // For old version compatibility
             url = [NSString stringWithFormat:@"http://www.bilibili.com/video/av%@/index_%@.html",params[@"aid"],params[@"pid"]];
         }
-
+        
         NSDictionary *o = @{
                             @"cid": [NSNumber numberWithInt:intcid] ,
                             @"quality": [NSNumber numberWithInt:quality],
                             @"isMP4": [NSNumber numberWithInt:intIsMp4],
                             @"url": url
                             };
-
+    
         NSData *d= [NSJSONSerialization dataWithJSONObject:o options:NSJSONWritingPrettyPrinted error:nil];
         NSString *jsonString = [[NSString alloc] initWithData:d encoding:NSUTF8StringEncoding];
         NSString *vjson = [plugin processEvent:@"bilibili-resolveAddr" :jsonString];
         if(vjson && [vjson length] > 5){
             NSData *jsonData = [vjson dataUsingEncoding:NSUTF8StringEncoding];
-
+            
             NSError * error = nil;
             NSMutableDictionary *videoResult = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-
+            
             if(error || !videoResult){
                 NSLog(@"[VP_Bilibili] JSON Parse Error: %@",error);
                 [NSException raise:@VP_BILI_JSON_ERROR format:@"%@", error.localizedDescription];
                 return NULL;
             }
-
+            
             NSLog(@"[VP_Bilibili] Dynamic parse success");
-
+            
             return videoResult;
-
+            
         }else{
             [NSException raise:@VP_BILI_DYN_PARSER_ERROR format:@"视频解析出现错误，且云端动态解析模块也无法解析，可能该版本已失效，请升级到最新版，或稍后重新启动软件再试。"];
         }
@@ -405,7 +425,7 @@ genAddress: FLVFailRetry = NO;
         NSLog(@"[VP_Bilibili] Can't load dynamic parser");
         [NSException raise:@VP_BILI_DYN_PARSER_ERROR format:@"视频解析出现错误，且云端动态解析模块未安装，请升级到最新版，或重新启动软件再试。"];
     }
-
+    
     return NULL;
 }
 
@@ -433,14 +453,14 @@ genAddress: FLVFailRetry = NO;
 
 - (NSString *)getFakeIP: (NSDictionary *)params{
     int fakeType = [[ud objectForKey:@"iptype"] intValue];
-
+    
     NSString *xff = [ud objectForKey:@"xff"];
-
+    
     NSString *title = params[@"title"];
     if(title && [title containsString:@"MIMI"]){
         fakeType = 2; // Force set XFF to Hong Kong IP
     }
-
+    
     if(fakeType == 2){
         xff = [ud objectForKey:@"xff_HK2"];
         if(!xff){
@@ -448,7 +468,7 @@ genAddress: FLVFailRetry = NO;
             [ud setObject:xff forKey:@"xff_HK2"];
         }
     }
-
+    
     return xff;
 }
 
@@ -457,9 +477,9 @@ genAddress: FLVFailRetry = NO;
     const char *cStr = [input UTF8String];
     unsigned char digest[16];
     CC_MD5( cStr, (CC_LONG)strlen(cStr), digest ); // This is the md5 call
-
+    
     NSMutableString *md5 = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
-
+    
     for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++)
         [md5 appendFormat:@"%02x", digest[i]];
     return md5;
@@ -468,11 +488,11 @@ genAddress: FLVFailRetry = NO;
 - (NSString *)getRandomHWID {
     NSString *letters = @"abcdef0123456789";
     NSMutableString *randomString = [NSMutableString stringWithCapacity:16];
-
+    
     for (int i=0; i<16; i++) {
         [randomString appendFormat: @"%C", [letters characterAtIndex: arc4random_uniform((int)[letters length]-1)]];
     }
-
+    
     return randomString;
 }
 

--- a/bilibili/VideoProvider/VP_Bilibili.m
+++ b/bilibili/VideoProvider/VP_Bilibili.m
@@ -30,14 +30,14 @@
     self = [super init];
     if(self) {
         ud = [NSUserDefaults standardUserDefaults];
-        
+
         // HWID
         self.hwid = [ud objectForKey:@"hwid_2"];
         if([self.hwid length] < 4){
             self.hwid  = [self getRandomHWID];
             [ud setObject:self.hwid forKey:@"hwid_2"];
         }
-        
+
         self.userAgent = @"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36";
     }
     return self;
@@ -52,13 +52,13 @@
         params[@"live"] = @"true";
         return params;
     }
-    
+
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\/video\\/av(\\d+)(\\/index.html|\\/index_(\\d+).html)?" options:NSRegularExpressionCaseInsensitive error:nil];
-    
+
     NSTextCheckingResult *match = [regex firstMatchInString:URL options:0 range:NSMakeRange(0, [URL length])];
-    
+
     NSRange aidRange = [match rangeAtIndex:1];
-    
+
     if(aidRange.length > 0){
         params[@"aid"] = [URL substringWithRange:aidRange];
         NSRange pidRange = [match rangeAtIndex:3];
@@ -71,52 +71,52 @@
         params[@"aid"] = @"0";
         params[@"pid"] = @"1";
     }
-    
+
     params[@"url"] = URL;
-    
+
     return params;
 }
 
 - (NSString *)getPlaybackRequestURL: (NSDictionary *)params{
     int quality = [self getQuality];
     NSString *type = [self getFormat:[params[@"download"] boolValue]];
-    
+
     NSLog(@"[VP_Bilibili] AV: %@, CID: %@, PID: %@", params[@"aid"], params[@"cid"], params[@"pid"]);
-    
+
     [self writeHistory:params[@"cid"] :params[@"aid"]];
-    
+
 //    NSString *req_path = [NSString stringWithFormat:@"platform=android&_device=android&_hwid=%@&_aid=%@&_tid=0&_p=%@&_down=0&cid=%@&quality=%d&otype=json&appkey=%@&type=%@",
 //                          self.hwid, // Hardware ID ( Generate on first start )
 //                          params[@"aid"], // Page ID ( AV )
 //                          params[@"pid"], // Page Number
 //                          params[@"cid"], // Video ID
 //                          quality,APIKey,type];
-//    
+//
 //    NSString *req_sign = [self getSign:req_path];
-//    
+//
 //    NSString *req_url = [NSString stringWithFormat:@"http://interface.bilibili.com/playurl?%@&sign=%@",req_path,req_sign];
 
     int rnd = arc4random_uniform(9999);
-    
+
     NSString *req_path = [NSString stringWithFormat:@"platform=android&cid=%@&quality=%d&otype=json&appkey=%@&type=%@&rnd=%d",
                           params[@"cid"], // Video ID
                           quality,APIKey,type,rnd];
-    
+
     NSString *req_sign = [self getSign:req_path];
-    
+
     NSString *req_url = [NSString stringWithFormat:@"http://interface.bilibili.com/playurl?%@&sign=%@",req_path,req_sign];
-    
+
     NSLog(@"[VP_Bilibili] API Request URL: %@", req_url);
-    
+
     return req_url;
 }
 
 - (NSString *)getLiveRequestURL: (NSDictionary *)params{
     NSLog(@"[VP_Bilibili] LiveRoom: %@", params[@"cid"]);
-    
+
 //    NSString *uuid = [[NSUUID UUID] UUIDString];
 //    NSString *hwid = [self getRandomHWID];
-//    
+//
 //    NSString *req_path = [NSString stringWithFormat:@"platform=android&_appver=406001&_buvid=%@infoc&_device=android&_hwid=%@&_aid=0&_tid=0&_p=%@&_down=0&cid=%@&quality=1&otype=json&appkey=%@&type=mp4",
 //                          uuid, // BUVID ( Unkown , Random here )
 //                          hwid, // Hardware ID ( Random here , avoid BUVID
@@ -125,21 +125,21 @@
 //                          APIKey];
 //
 //    NSString *req_sign = [self getSign:req_path];
-//    
+//
 //    NSString *req_url = [NSString stringWithFormat:@"http://live.bilibili.com/api/playurl?%@&sign=%@",req_path,req_sign];
 
     int rnd = arc4random_uniform(9999);
-    
+
     NSString *req_path = [NSString stringWithFormat:@"platform=android&cid=%@&quality=1&otype=json&appkey=%@&type=mp4&rnd=%d",
                           params[@"cid"], // Video ID
                           APIKey,rnd];
-    
+
     NSString *req_sign = [self getSign:req_path];
-    
+
     NSString *req_url = [NSString stringWithFormat:@"http://live.bilibili.com/api/playurl?%@&sign=%@",req_path,req_sign];
-    
+
     NSLog(@"[VP_Bilibili] API Request URL: %@", req_url);
-    
+
     return req_url;
 }
 
@@ -153,36 +153,57 @@
 //          "download":true
 //      }
 
+
+- (NSString *) parseLiveURL: (NSString *)url {
+    NSLog(@"[liveline]: origin url: %@", url);
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@".*?(live_.*?.flv).*?" options:NSRegularExpressionCaseInsensitive error:nil];
+    NSTextCheckingResult *match = [regex firstMatchInString:url options:0 range:NSMakeRange(0, [url length])];
+
+    NSRange aidRange = [match rangeAtIndex:1];
+
+    if(aidRange.length > 0){
+        NSString* new_url = [url substringWithRange:aidRange];
+        NSString* liveLine = (NSString *)[ud objectForKey:@"liveLine"];
+        NSLog(@"[liveLine]: %@", liveLine);
+        if ([liveLine isEqualToString:@"原始地址"]) {
+            return url;
+        }
+        NSLog(@"[regex]: %@", new_url);
+        return [NSString stringWithFormat:@"%@%@", liveLine, new_url];
+    }
+    return url;
+}
+
 - (VideoAddress *) getVideoAddress: (NSDictionary *)params{
     if(!params[@"cid"]){
         [NSException raise:@VP_PARAM_ERROR format:@"CID Cannot be empty"];
         return NULL;
     }
-                      
+
 getUrl: NSLog(@"[VP_Bilibili] Getting video url");
 
     NSString *pbUrl;
-    
+
     if(!params[@"live"]){
         pbUrl = [self getPlaybackRequestURL:params];
     }else{
         pbUrl = [self getLiveRequestURL:params];
     }
-    
+
     NSURL* URL = [NSURL URLWithString:pbUrl];
-    
+
     NSString *fakeIP = [self getFakeIP:params];
 
     NSDictionary *videoResult;
-    
+
     // Their offical android/ios client is using dynamic downloaded lua to parse video
     // So I've implemented a lua interpreter , will find the appkey & secret automatically
     // My continuous integration server will build new dynamic library if new key detected
     // This program will download new dynamic library on startup, and verify the digital signature of  library, load it into memory
-    
-    
+
+
     // Build-in parser's result(ws.acgvideo.com/path.flv?*&or=xxx the "or" param) have speed limit , so use dynamic parser by default
-    
+
 #ifndef DEBUG
     VP_Plugin *plugin = [[PluginManager sharedInstance] Get:@"bilibili-resolveAddr"];
     if(plugin){
@@ -197,9 +218,9 @@ getUrl: NSLog(@"[VP_Bilibili] Getting video url");
     }
 #endif
 
-    
+
 parseJSON: NSLog(@"[VP_Bilibili] Parsing result");
-    
+
     NSArray *dUrls = [videoResult objectForKey:@"durl"];
     if([dUrls count] == 0 || ![videoResult objectForKey:@"result"]){
         if(FLVFailRetry){
@@ -216,53 +237,65 @@ parseJSON: NSLog(@"[VP_Bilibili] Parsing result");
             goto getUrl;
         }
     }
-    
+
 genAddress: FLVFailRetry = NO;
-    
+
     VideoAddress *video = [[VideoAddress alloc] init];
     [video setUserAgent:self.userAgent];
-    
+
     BOOL URLisString = [[[dUrls valueForKey:@"url"] className] isEqualToString:@"__NSCFString"];
-    
+
     if(URLisString){ // URL is String ( Some old videos , Single fragment )
-        
+
+
+
         NSString *url = [dUrls valueForKey:@"url"];
         [video addDefaultPlayURL:url];
+
+        url = [self parseLiveURL: url];
         [video setFirstFragmentURL:url];
-        
+        NSLog(@"[parsed_url]: %@", url);
+
     }else if([dUrls count] == 1){ // URL is Array ( Most MP4 videos, Single fragment )
-        
+
         NSString *url = [[dUrls objectAtIndex:0] valueForKey:@"url"];
+
+        url = [self parseLiveURL: url];
         [video addDefaultPlayURL:url];
+        NSLog(@"[parsed_url]: %@", url);
+
         [video setFirstFragmentURL:url];
-        
+
         NSArray *bUrls = [[dUrls objectAtIndex:0] valueForKey:@"backup_url"];
         if([bUrls count] > 0){
             for (NSString *burl in bUrls) {
                 [video addBackupURL:@[burl]];
             }
         }
-        
+
     }else{ // URL is Array ( Most FLV videos, Multi fragment )
-        
+
         for (NSDictionary *match in dUrls) {
             NSString *url = [match valueForKey:@"url"];
             if(![[video firstFragmentURL] length]){ // Set first fragment url
                 [video setFirstFragmentURL:url];
             }
-            
+
+            url = [self parseLiveURL: url];
             [video addDefaultPlayURL:url];
+            NSLog(@"[parsed_url]: %@", url);
+
         }
-        
+
     }
-    
+
     // Sina old video ( only flv )
     if([[video firstFragmentURL] isEqualToString:@"http://v.iask.com/v_play_ipad.php?vid=false"]){
         FLVFailRetry = YES;
         NSLog(@"[VP_Bilibili] Retring resolve with FLV format");
         goto getUrl;
     }
-    
+
     // Anti Hot Linking
 
     if([[video firstFragmentURL] containsString:@".hdslb."] || // *.hdslb.* only have static content
@@ -272,7 +305,7 @@ genAddress: FLVFailRetry = NO;
         videoResult = [self dynamicPluginParser:params];
         goto parseJSON;
     }
-    
+
     return video;
 }
 
@@ -280,13 +313,13 @@ genAddress: FLVFailRetry = NO;
     NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:URL];
     request.HTTPMethod = @"GET";
     request.timeoutInterval = 5;
-    
-    
+
+
     if(fakeIP){
         [request setValue:fakeIP forHTTPHeaderField:@"X-Forwarded-For"];
         [request setValue:fakeIP forHTTPHeaderField:@"Client-IP"];
     }
-    
+
 //    [request setValue:[ud objectForKey:@"cookie"] forHTTPHeaderField:@"Cookie"];
 //    [request setValue:self.userAgent forHTTPHeaderField:@"User-Agent"];
 //    [request setValue:@"trailers" forHTTPHeaderField:@"TE"];
@@ -306,15 +339,14 @@ genAddress: FLVFailRetry = NO;
         [NSException raise:@VP_BILI_API_ERROR format:@"视频解析出现错误，返回内容为空，可能的原因：\n1. 您的网络连接出现故障\n2. Bilibili API 服务器出现故障\n请尝试以下步骤：\n1. 更换网络连接或重启电脑\n2. 可能触发了频率限制，请更换 IP 地址\n\n如果您确信是软件问题，请点击帮助 -- 反馈"];
         return NULL;
     }
-    
     NSMutableDictionary *videoResult = [NSJSONSerialization JSONObjectWithData:respData options:0 error:&error];
-    
+
     if(error){
         NSLog(@"[VP_Bilibili] JSON Parse Error: %@",error);
         [NSException raise:@VP_BILI_JSON_ERROR format:@"视频解析出现错误，JSON 解析失败，可能的原因：\n1. 您的网络被劫持\n2. Bilibili 服务器出现故障\n请尝试以下步骤：\n1. 尝试更换网络\n2. 过一会再试\n\n如果您确信是软件问题，请点击帮助 -- 反馈"];
         return NULL;
     }
-    
+
     return videoResult;
 }
 
@@ -333,39 +365,39 @@ genAddress: FLVFailRetry = NO;
         if([type isEqualToString:@"mp4"]){
             intIsMp4 = 1;
         }
-        
+
         NSString *url = params[@"url"];
         if(!url){
             // For old version compatibility
             url = [NSString stringWithFormat:@"http://www.bilibili.com/video/av%@/index_%@.html",params[@"aid"],params[@"pid"]];
         }
-        
+
         NSDictionary *o = @{
                             @"cid": [NSNumber numberWithInt:intcid] ,
                             @"quality": [NSNumber numberWithInt:quality],
                             @"isMP4": [NSNumber numberWithInt:intIsMp4],
                             @"url": url
                             };
-    
+
         NSData *d= [NSJSONSerialization dataWithJSONObject:o options:NSJSONWritingPrettyPrinted error:nil];
         NSString *jsonString = [[NSString alloc] initWithData:d encoding:NSUTF8StringEncoding];
         NSString *vjson = [plugin processEvent:@"bilibili-resolveAddr" :jsonString];
         if(vjson && [vjson length] > 5){
             NSData *jsonData = [vjson dataUsingEncoding:NSUTF8StringEncoding];
-            
+
             NSError * error = nil;
             NSMutableDictionary *videoResult = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-            
+
             if(error || !videoResult){
                 NSLog(@"[VP_Bilibili] JSON Parse Error: %@",error);
                 [NSException raise:@VP_BILI_JSON_ERROR format:@"%@", error.localizedDescription];
                 return NULL;
             }
-            
+
             NSLog(@"[VP_Bilibili] Dynamic parse success");
-            
+
             return videoResult;
-            
+
         }else{
             [NSException raise:@VP_BILI_DYN_PARSER_ERROR format:@"视频解析出现错误，且云端动态解析模块也无法解析，可能该版本已失效，请升级到最新版，或稍后重新启动软件再试。"];
         }
@@ -373,7 +405,7 @@ genAddress: FLVFailRetry = NO;
         NSLog(@"[VP_Bilibili] Can't load dynamic parser");
         [NSException raise:@VP_BILI_DYN_PARSER_ERROR format:@"视频解析出现错误，且云端动态解析模块未安装，请升级到最新版，或重新启动软件再试。"];
     }
-    
+
     return NULL;
 }
 
@@ -401,14 +433,14 @@ genAddress: FLVFailRetry = NO;
 
 - (NSString *)getFakeIP: (NSDictionary *)params{
     int fakeType = [[ud objectForKey:@"iptype"] intValue];
-    
+
     NSString *xff = [ud objectForKey:@"xff"];
-    
+
     NSString *title = params[@"title"];
     if(title && [title containsString:@"MIMI"]){
         fakeType = 2; // Force set XFF to Hong Kong IP
     }
-    
+
     if(fakeType == 2){
         xff = [ud objectForKey:@"xff_HK2"];
         if(!xff){
@@ -416,7 +448,7 @@ genAddress: FLVFailRetry = NO;
             [ud setObject:xff forKey:@"xff_HK2"];
         }
     }
-    
+
     return xff;
 }
 
@@ -425,9 +457,9 @@ genAddress: FLVFailRetry = NO;
     const char *cStr = [input UTF8String];
     unsigned char digest[16];
     CC_MD5( cStr, (CC_LONG)strlen(cStr), digest ); // This is the md5 call
-    
+
     NSMutableString *md5 = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
-    
+
     for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++)
         [md5 appendFormat:@"%02x", digest[i]];
     return md5;
@@ -436,11 +468,11 @@ genAddress: FLVFailRetry = NO;
 - (NSString *)getRandomHWID {
     NSString *letters = @"abcdef0123456789";
     NSMutableString *randomString = [NSMutableString stringWithCapacity:16];
-    
+
     for (int i=0; i<16; i++) {
         [randomString appendFormat: @"%C", [letters characterAtIndex: arc4random_uniform((int)[letters length]-1)]];
     }
-    
+
     return randomString;
 }
 

--- a/bilibili/VideoProvider/VP_Bilibili.m
+++ b/bilibili/VideoProvider/VP_Bilibili.m
@@ -350,19 +350,20 @@ genAddress: FLVFailRetry = NO;
         NSLog(@"[xml response]:%@", rt);
         NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"<!\\[CDATA\\[(http.*)\\]\\]><\\/.*url>" options:NSRegularExpressionCaseInsensitive error:nil];
         
-        NSArray<NSTextCheckingResult *> *match_new = [regex matchesInString:rt options:0 range:NSMakeRange(0, [rt length])];
-        NSMutableArray *result = [[NSMutableArray alloc]initWithCapacity:[match_new count]];
-        for (int i = 0; i < [match_new count]; i++) {
-            NSRange rg = [[match_new objectAtIndex:i] rangeAtIndex:1];
-            if (rg.length > 0){
-                NSString* rt_new = [rt substringWithRange:rg];
-                NSLog(@"%@", rt_new);
-                [result insertObject:rt_new atIndex:i];
+        NSArray<NSTextCheckingResult *> *match = [regex matchesInString:rt options:0 range:NSMakeRange(0, [rt length])];
+        if (match){
+            NSMutableArray *result = [[NSMutableArray alloc]initWithCapacity:[match count]];
+            for (int i = 0; i < [match count]; i++) {
+                NSRange rg = [[match objectAtIndex:i] rangeAtIndex:1];
+                if (rg.length > 0){
+                    NSString* rt_new = [rt substringWithRange:rg];
+                    NSLog(@"%@", rt_new);
+                    [result insertObject:rt_new atIndex:i];
+                }
             }
+            NSDictionary *dict1 = [NSDictionary dictionaryWithObject:result forKey:@"durl"];
+            return dict1;
         }
-        NSDictionary *dict1 = [NSDictionary dictionaryWithObject:result forKey:@"durl"];
-        return dict1;
-        
         [NSException raise:@VP_BILI_JSON_ERROR format:@"视频解析出现错误，JSON 解析失败，可能的原因：\n1. 您的网络被劫持\n2. Bilibili 服务器出现故障\n请尝试以下步骤：\n1. 尝试更换网络\n2. 过一会再试\n\n如果您确信是软件问题，请点击帮助 -- 反馈"];
         return NULL;
     }


### PR DESCRIPTION
从来木有写过Objective-C TAT。。追踪好久发现直播一直木有换线设置，我家网又令人难受。。所以就仿照作者的写法撸了个换线。。

要是质量不可以merge的话，还请作者亲自实现一下TAT...有官方支持当然好了

ps: 应该有更好的办法= = 通过live API获取的URL，若输出格式为json的话，确实只有一个地址。若是xml的话，就有四个啦~不过试验了很多次，发现几条线路的请求地址前缀都相同，所以就直接写在配置里了。
